### PR TITLE
Modify & Cancel Booking Bugfix

### DIFF
--- a/ProjectB/Logic/BookingLogic.cs
+++ b/ProjectB/Logic/BookingLogic.cs
@@ -101,10 +101,12 @@ public static class BookingLogic
 
     public static List<BookingModel> GetBookingsForUser(int userId, bool upcoming)
     {
-        var all = BookingAccessService.GetBookingsByUser(userId);
-        var now = DateTime.Now;
+        List<BookingModel> all = BookingAccessService.GetBookingsByUser(userId);
+        DateTime now = DateTime.Now;
         return all.Where(b =>
         {
+            if (b.BookingStatus == "Cancelled")
+                return !upcoming;
             return upcoming ? b.DepartureTime >= now : b.DepartureTime < now;
         }).ToList();
     }
@@ -140,10 +142,9 @@ public static class BookingLogic
 
     public static bool ModifyBooking(int bookingId, string newSeatId, int newLuggageAmount)
     {
-        var booking = BookingAccessService.GetBookingById(bookingId);
+        BookingModel booking = BookingAccessService.GetBookingById(bookingId);
         if (booking == null)
         {
-            AnsiConsole.MarkupLine($"[red]Booking with ID {bookingId} not found.[/]");
             return false;
         }
 
@@ -154,18 +155,7 @@ public static class BookingLogic
         booking.LuggageAmount = newLuggageAmount;
         BookingAccessService.UpdateBooking(booking);
 
-        AnsiConsole.MarkupLine($"[green]Booking with ID {bookingId} has been updated.[/]");
         return true;
-    }
-
-    public static void CheckFlightAvailability(int flightID)
-    {
-        // Use flightID for seat map and booking
-        List<SeatModel> seats = SeatMapLogic.GetSeatMap(flightID);
-        if (seats == null || seats.Count == 0)
-        {
-            throw new ArgumentException($"No seats available for flight ID {flightID}.");
-        }
     }
 
     public static void BookTheDamnFlight(BookingModel booking)

--- a/ProjectB/Presentation/UserUI.cs
+++ b/ProjectB/Presentation/UserUI.cs
@@ -411,22 +411,26 @@ public static class UserUI
             var action = AnsiConsole.Prompt(
                 new SelectionPrompt<string>()
                     .Title("[#864000]Bookings menu:[/]")
-                    .AddChoices("View upcoming bookings", "Cancel a booking", "Modify a booking", "View past bookings", "Back to main menu")
+                    .AddChoices("Cancel a booking", "Modify a booking", "View upcoming bookings", "View past bookings", "Back to main menu")
             );
 
-            if (action == "View upcoming bookings")
-            {
-                BookingUI.ViewUserBookings(true);
-                AnsiConsole.Clear();
-            }
-            else if (action == "Cancel a booking")
+            if (action == "Cancel a booking")
             {
                 BookingUI.CancelBookingPrompt();
+                AnsiConsole.WriteLine("Press any key to continue...");
+                Console.ReadKey(true);
                 AnsiConsole.Clear();
             }
             else if (action == "Modify a booking")
             {
                 BookingUI.ModifyBookingPrompt();
+                AnsiConsole.WriteLine("Press any key to continue...");
+                Console.ReadKey(true);
+                AnsiConsole.Clear();
+            }
+            else if (action == "View upcoming bookings")
+            {
+                BookingUI.ViewUserBookings(true);
                 AnsiConsole.Clear();
             }
             else if (action == "View past bookings")
@@ -441,7 +445,6 @@ public static class UserUI
             }
         }
     }
-
 
     public static void ShowGuestMenu()
     {


### PR DESCRIPTION
New private method in BookingUI handling everything concerning the displaying of the seatmap and the selection of the seat.
Modified DisplayBookingDetails to now only "send" an email address when booking the flight instead of also doing it any time the method is called upon.
Modified Additional Luggage to now get rid of ugly markup lines and instead display a proper message.
Modified AdditionalLuggage and CancellationInsurance to display extra information.
Modifed AddCouponCode to now keep asking for a coupon code after agreeing that you have a code. It'll keep asking until the code filled in is a valid coupon code or until left empty, causing it to return its respective "answer".
Updated Legenda to now also display the pricing of the seats so that the user knows how much the seat will cost during the booking process.
Modified ModifyBookingPrompt to now displayt the seatmap for selecting a different seat.
Made sure Cancellation and Modification of booking is now properly integrated.
Made sure that cancelled flight are marked as "past flights" causing them to 1. only show up in past bookings & 2. be non-eligible for modification of a flight.